### PR TITLE
Visualize property drawer on edit-entry

### DIFF
--- a/helm-org-contacts.el
+++ b/helm-org-contacts.el
@@ -278,7 +278,8 @@ ALIST that have PROP as the key."
   (widen)
   (show-all)
   (goto-char (car entry))
-  (org-narrow-to-subtree))
+  (org-narrow-to-subtree)
+  (org-show-all))
 
 (setq helm-source-org-contacts
       '((name                           . "Contacts")


### PR DESCRIPTION
Since most of the contact information is in the property drawer,  it makes sense to show it by default when the 'edit entry' functionality is selected.